### PR TITLE
Support for Tinyows WFS-T server

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
         <meta charset="utf-7">
         <title>WFS-T Leaflet Plugin</title>
 
-        <!-- Leaflet 0.6.4 CSS/JS from CDN -->
-        <link type="text/css" rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
+        <!-- Leaflet 0.7.3 CSS/JS from CDN -->
+        <link type="text/css" rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
         <!--[if lte IE 8]>
-        <link type="text/css" rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" />
+        <link type="text/css" rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.ie.css" />
         <![endif]-->
-        <script type="text/javascript" src="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.js"></script>
+        <script type="text/javascript" src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
 
 
         <!-- Leaflet Draw 0.2.0 (you'll need to download these -->

--- a/js/leaflet.wfst.js
+++ b/js/leaflet.wfst.js
@@ -16,7 +16,7 @@ L.WFST = L.GeoJSON.extend({
             showExisting: true,         // Show existing features in WFST layer on map?
             version: "1.1.0",           // WFS version 
             failure: function(msg){},    // Function for handling initialization failures
-            xsdNs: 'xsd:'
+            xsdNs: 'xsd'
             // geomField : <field_name> // The geometry field to use. Auto-detected if only one geom field 
             // url: <WFS service URL> 
             // featureNS: <Feature NameSpace>
@@ -452,7 +452,7 @@ L.WFST = L.GeoJSON.extend({
         _xmlpre += '<wfs:Transaction service="WFS" version="1.1.0"'; 
         _xmlpre += ' xmlns:wfs="http://www.opengis.net/wfs"';
         _xmlpre += ' xmlns:gml="http://www.opengis.net/gml"';
-        _xmlpre += ' xmlns:' + this.options.featureNS + '="' + this._getElementsByTagName(this.options.featureinfo, this.options.xsdNs + 'schema')[0].getAttribute('targetNamespace') + '"';
+        _xmlpre += ' xmlns:' + this.options.featureNS + '="' + this._getElementsByTagName(this.options.featureinfo, this.options.xsdNs + ':schema')[0].getAttribute('targetNamespace') + '"';
         _xmlpre += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"';
         _xmlpre += ' xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd';
         //_xmlpre += ' ' + this.options.url + '?service=WFS&version=1.1.0&request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
@@ -474,11 +474,11 @@ L.WFST = L.GeoJSON.extend({
     },
 
     _fieldsByAttribute: function(attribute,value,max){
-        var seq = this._getElementsByTagName(this.options.featureinfo, this.options.xsdNs + 'sequence')[0];
+        var seq = this._getElementsByTagName(this.options.featureinfo, this.options.xsdNs + ':sequence')[0];
         if(typeof seq == 'undefined'){
             return [];
         }
-        var elems = this._getElementsByTagName(seq, this.options.xsdNs + 'element');
+        var elems = this._getElementsByTagName(seq, this.options.xsdNs + ':element');
         var found = [];
 
         var foundVal;

--- a/js/leaflet.wfst.js
+++ b/js/leaflet.wfst.js
@@ -15,12 +15,14 @@ L.WFST = L.GeoJSON.extend({
         var initOptions = L.extend({
             showExisting: true,         // Show existing features in WFST layer on map?
             version: "1.1.0",           // WFS version 
-            failure: function(msg){}    // Function for handling initialization failures
+            failure: function(msg){},    // Function for handling initialization failures
+            xsdNs: 'xsd:'
             // geomField : <field_name> // The geometry field to use. Auto-detected if only one geom field 
             // url: <WFS service URL> 
             // featureNS: <Feature NameSpace>
             // featureType: <Feature Type>
             // primaryKeyField: <The Primary Key field for using when doing deletes and updates>
+            // xsdNs: Namespace used in XSD schemas, XSD returned by TinyOWS uses 'xs:' while GeoServer uses 'xsd:'
         },options);
 
 
@@ -317,7 +319,7 @@ L.WFST = L.GeoJSON.extend({
                 }
             }else if(
                 elems[p].getAttribute('type') === 'gml:GeometryPropertyType' || 
-                elems[p].getAttribute('type') === 'gml:GeometryPropertyType' || 
+                elems[p].getAttribute('type') === 'gml:PointPropertyType' || 
                 elems[p].getAttribute('type') === 'gml:MultiSurfacePropertyType' || 
                 elems[p].getAttribute('type') === 'gml:SurfacePropertyType' 
             ){
@@ -333,7 +335,7 @@ L.WFST = L.GeoJSON.extend({
         // Only require a geometry field if it looks like we have geometry but we aren't trying to save it
         if(
             (layer.hasOwnProperty('x') && layer.hasOwnProperty('y') && typeof layer.x != 'undefined' && typeof layer.y != 'undefined') ||
-            (layer.hasOwnProperty('_latlngs') && layer._latlngs.length > 0)
+            (layer.hasOwnProperty('_latlng') && Object.keys(layer._latlng).length > 0)
         ){
             if(this.options.geomField || geomFields.length === 1){
                 this.options.geomField = this.options.geomField || geomFields[0].getAttribute('name');
@@ -348,14 +350,14 @@ L.WFST = L.GeoJSON.extend({
     },
     // Make WFS-T filters for deleting/updating specific items
     _whereFilter: function(where){
-        var xml = '<' + this.options.featureNS + ':Filter>';
+        var xml = '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">';
         for(var propertyName in where){
-            xml += '<PropertyIsEqualTo>';
-            xml += '<PropertyName>' + propertyName + '</PropertyName>';
-            xml += '<Literal>' + where[propertyName] + '</Literal>';
-            xml += '</PropertyIsEqualTo>'; 
+            xml += '<ogc:PropertyIsEqualTo>';
+            xml += '<ogc:PropertyName>' + propertyName + '</ogc:PropertyName>';
+            xml += '<ogc:Literal>' + where[propertyName] + '</ogc:Literal>';
+            xml += '</ogc:PropertyIsEqualTo>'; 
         }
-        xml += '</' + this.options.featureNS+ ':Filter>';
+        xml += '</ogc:Filter>';
         return xml;
     },
 
@@ -394,7 +396,7 @@ L.WFST = L.GeoJSON.extend({
     Get all existing objects from the WFS service and draw them
     */
     _loadExistingFeatures: function(){
-        var geoJsonUrl = this.options.url + '?service=WFS&version=1.0.0&request=GetFeature&typeName=' + this.options.featureNS + ':' + this.options.featureType + '&outputFormat=json';
+        var geoJsonUrl = this.options.url + '?service=WFS&version=1.0.0&request=GetFeature&typeName=' + this.options.featureNS + ':' + this.options.featureType + '&outputFormat=application/json';
         this._ajax({
             url: geoJsonUrl,
             success: function(res){
@@ -410,7 +412,7 @@ L.WFST = L.GeoJSON.extend({
     Get the feature description
     */
     _loadFeatureDescription: function(){
-        var describeFeatureUrl = this.options.url + '?request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
+        var describeFeatureUrl = this.options.url + '?service=WFS&version=1.0.0&request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
         this._ajax({
             url: describeFeatureUrl,
             success: function(res){
@@ -450,10 +452,10 @@ L.WFST = L.GeoJSON.extend({
         _xmlpre += '<wfs:Transaction service="WFS" version="1.1.0"'; 
         _xmlpre += ' xmlns:wfs="http://www.opengis.net/wfs"';
         _xmlpre += ' xmlns:gml="http://www.opengis.net/gml"';
-        _xmlpre += ' xmlns:' + this.options.featureNS + '="' + this._getElementsByTagName(this.options.featureinfo,'xsd:schema')[0].getAttribute('targetNamespace') + '"';
+        _xmlpre += ' xmlns:' + this.options.featureNS + '="' + this._getElementsByTagName(this.options.featureinfo, this.options.xsdNs + 'schema')[0].getAttribute('targetNamespace') + '"';
         _xmlpre += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"';
-        _xmlpre += ' xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-transaction.xsd';
-        _xmlpre += ' ' + this.options.url + '?request=DescribeFeatureType&amp;typename=' + this.options.featureNS + ':' + this.options.featureType;
+        _xmlpre += ' xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd';
+        //_xmlpre += ' ' + this.options.url + '?service=WFS&version=1.1.0&request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
         _xmlpre += '">';
 
         this.options._xmlpre = _xmlpre;
@@ -472,11 +474,11 @@ L.WFST = L.GeoJSON.extend({
     },
 
     _fieldsByAttribute: function(attribute,value,max){
-        var seq = this._getElementsByTagName(this.options.featureinfo,'xsd:sequence')[0];
+        var seq = this._getElementsByTagName(this.options.featureinfo, this.options.xsdNs + 'sequence')[0];
         if(typeof seq == 'undefined'){
             return [];
         }
-        var elems = this._getElementsByTagName(seq,'xsd:element');
+        var elems = this._getElementsByTagName(seq, this.options.xsdNs + 'element');
         var found = [];
 
         var foundVal;

--- a/js/leaflet.wfst.js
+++ b/js/leaflet.wfst.js
@@ -396,7 +396,7 @@ L.WFST = L.GeoJSON.extend({
     Get all existing objects from the WFS service and draw them
     */
     _loadExistingFeatures: function(){
-        var geoJsonUrl = this.options.url + '?service=WFS&version=1.0.0&request=GetFeature&typeName=' + this.options.featureNS + ':' + this.options.featureType + '&outputFormat=application/json';
+        var geoJsonUrl = this.options.url + '?service=WFS&version=' + this.options.version + '&request=GetFeature&typeName=' + this.options.featureNS + ':' + this.options.featureType + '&outputFormat=application/json';
         this._ajax({
             url: geoJsonUrl,
             success: function(res){
@@ -412,7 +412,7 @@ L.WFST = L.GeoJSON.extend({
     Get the feature description
     */
     _loadFeatureDescription: function(){
-        var describeFeatureUrl = this.options.url + '?service=WFS&version=1.0.0&request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
+        var describeFeatureUrl = this.options.url + '?service=WFS&version=' + this.options.version + '&request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
         this._ajax({
             url: describeFeatureUrl,
             success: function(res){
@@ -449,13 +449,13 @@ L.WFST = L.GeoJSON.extend({
 
         var _xmlpre = '';
         _xmlpre = '';
-        _xmlpre += '<wfs:Transaction service="WFS" version="1.1.0"'; 
+        _xmlpre += '<wfs:Transaction service="WFS" version="' + this.options.version + '"'; 
         _xmlpre += ' xmlns:wfs="http://www.opengis.net/wfs"';
         _xmlpre += ' xmlns:gml="http://www.opengis.net/gml"';
         _xmlpre += ' xmlns:' + this.options.featureNS + '="' + this._getElementsByTagName(this.options.featureinfo, this.options.xsdNs + ':schema')[0].getAttribute('targetNamespace') + '"';
         _xmlpre += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"';
-        _xmlpre += ' xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd';
-        //_xmlpre += ' ' + this.options.url + '?service=WFS&version=1.1.0&request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
+        _xmlpre += ' xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/' + this.options.version + '/wfs.xsd';
+        //_xmlpre += ' ' + this.options.url + '?service=WFS&version=' + this.options.version + '&request=DescribeFeatureType&typename=' + this.options.featureNS + ':' + this.options.featureType;
         _xmlpre += '">';
 
         this.options._xmlpre = _xmlpre;


### PR DESCRIPTION
Hi,

I've applied some changes in order to make this plugin work with TinyOWS WFS-T server:
- With TinyOWS, the schema returned by the DescribeFeatureType request uses 'xs' as namespace, while GeoServer uses 'xsd'. For this I've added an option to define the 'xsdNs', which defaults to 'xsd:'
- the Filter created by the _whereFilter function used 'this.options.featureNS' as namespace. Perhaps that works depending on the server config, but changing this simply to 'ocg' and including that namespace works with both GeoServer and TinyOWS 
- describeFeatureUrl does not include the 'service' and 'version' parameters, which are required by TinyOWS
- I had to disable including the schema returned by 'DescribeFeatureType' to be part of xsi:schemaLocation, in the wfs:Transaction XML message.

In general I've included a few fixes (I guess some were required due to the upgrade of Leaflet itself)
- 'layer' object contains '_latlng' property, not '_latlngs'.

I've tested and verified these changes to ensure it still works with GeoServer.

Could you have a look at this, and merge this PR is you are happy with it?
There are a few things I can polish up (in further PRs) if you like. For instance the WFS version is configurable as an option, but '1.0.0'. is hardcoded in the URLs constructed for the GetFeature and DescribeFeatureType calls.
